### PR TITLE
DS-000: Remove stylelint rule for ordering at-rule due to new SCSS behavior

### DIFF
--- a/generators/app/templates/theme/stylelintrc.json
+++ b/generators/app/templates/theme/stylelintrc.json
@@ -39,16 +39,8 @@
     "order/order": [
       "custom-properties",
       "dollar-variables",
-      {
-        "type": "at-rule",
-        "hasBlock": false
-      },
       "declarations",
-      "rules",
-      {
-        "type": "at-rule",
-        "hasBlock": true
-      }
+      "rules"
     ],
     "order/properties-order": [
       "position",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@specbeelabs/drupal-theme-init",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "description": "A Yeoman generator to scaffold and initialize a Drupal theme.",
   "homepage": "https://github.com/SpecbeeLabs/drupal-theme-init",
   "author": "Sagar <sagar@specbee.com> (https://specbee.com)",


### PR DESCRIPTION
The new SCSS compilation causes deprecation issues if at-rules are not not placed properly. The ordering lint rule causes that deprecated warning, hence removing that rule.